### PR TITLE
fix: command not found

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,16 +58,24 @@ describe('test/index.test.ts', () => {
       .end();
   });
 
-  it('should show command not found', async () => {
+  it('should show help info when throw error', async () => {
     await run('my-bin', 'notexistscommand -h')
-      // .debug()
-      .expect('stderr', /Command not found: 'my-bin notexistscommand -h'/)
+      .debug()
+      .expect('stderr', /Unknown command/)
+      .expect('stderr', /notexistscommand/)
       .expect('stderr', /try 'my-bin --help' for more information/)
       .end();
 
     await run('my-bin', 'dev abc bbc')
-      // .debug()
-      .expect('stderr', /Command not found: 'my-bin dev abc bbc'/)
+      .debug()
+      .expect('stderr', /Unknown commands/)
+      .expect('stderr', /bbc/)
+      .expect('stderr', /try 'my-bin dev --help' for more information/)
+      .end();
+
+    await run('my-bin', 'dev abc --bbc')
+      .debug()
+      .expect('stderr', /Unknown options: --bbc/)
       .expect('stderr', /try 'my-bin dev --help' for more information/)
       .end();
   });


### PR DESCRIPTION
应该只有抛错时，再在错误信息后面加上 `--help` 的提示，而不是所有都抛 command not found