### PR TITLE
fix: catch built-in error only

### DIFF
--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,4 +1,4 @@
-import { Inject, ApplicationLifecycle, LifecycleHook, LifecycleHookUnit, Program, CommandContext, Utils } from '@artus-cli/artus-cli';
+import { Inject, ApplicationLifecycle, LifecycleHook, LifecycleHookUnit, Program, CommandContext, Utils, ArtusCliError } from '@artus-cli/artus-cli';
 
 @LifecycleHookUnit()
 export default class UsageLifecycle implements ApplicationLifecycle {
@@ -27,9 +27,13 @@ export default class UsageLifecycle implements ApplicationLifecycle {
       try {
         await next();
       } catch(e) {
-        // can not match any command
-        console.error(`\n ${e.message}, try '${ctx.fuzzyMatched.cmds.join(' ') || bin} --help' for more information.\n`);
-        process.exit(1);
+        if (e instanceof ArtusCliError) {
+          // built-in error in artus-cli
+          console.error(`\n ${e.message}, try '${ctx.fuzzyMatched.cmds.join(' ') || bin} --help' for more information.\n`);
+          process.exit(1);
+        }
+
+        throw e;
       }
     });
   }

--- a/test/fixtures/my-bin/cmd/dev.ts
+++ b/test/fixtures/my-bin/cmd/dev.ts
@@ -19,10 +19,17 @@ export class DevCommand extends Command {
   })
   inspect: boolean;
 
+  @Option({
+    default: false,
+  })
+  throw: boolean;
+
   @Option()
   nodeFlags: string;
 
   async run() {
-    // nothing
+    if (this.throw) {
+      throw new Error('custom error');
+    }
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -58,7 +58,7 @@ describe('test/index.test.ts', () => {
       .end();
   });
 
-  it('should show help info when throw error', async () => {
+  it('should show help info when throw built-in error', async () => {
     await run('my-bin', 'notexistscommand -h')
       .debug()
       .expect('stderr', /Command is not found/)
@@ -77,6 +77,15 @@ describe('test/index.test.ts', () => {
       .debug()
       .expect('stderr', /Unknown options: --bbc/)
       .expect('stderr', /try 'my-bin dev --help' for more information/)
+      .end();
+  });
+
+  it('should not show help info when throw custom error', async () => {
+    await run('my-bin', 'dev --throw')
+      .debug()
+      .expect('stderr', /custom error/)
+      .expect('stderr', /my-bin\/cmd\/dev\.ts:\d+:\d+/)
+      .notExpect('stderr', /try 'my-bin dev --help' for more information/)
       .end();
   });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -84,7 +84,7 @@ describe('test/index.test.ts', () => {
     await run('my-bin', 'dev --throw')
       .debug()
       .expect('stderr', /custom error/)
-      .expect('stderr', /my-bin\/cmd\/dev\.ts:\d+:\d+/)
+      .expect('stderr', /my-bin[\/\\]cmd[\/\\]dev\.ts:\d+:\d+/)
       .notExpect('stderr', /try 'my-bin dev --help' for more information/)
       .end();
   });


### PR DESCRIPTION
只有抛出 artus-cli 错误的时候才吃掉堆栈，优化错误信息