### PR TITLE
feat: support print examples

### DIFF
--- a/src/help.ts
+++ b/src/help.ts
@@ -29,16 +29,35 @@ export class HelpCommand extends Command {
     const optionKeys = helpCommand.options ? Object.keys(helpCommand.options) : [];
 
     // usage info in first line
-    displayTexts.push(`Usage: ${helpCommand.command.startsWith(bin) ? '' : `${bin} `}${helpCommand.command}`);
+    displayTexts.push(
+      'Usage: ' +
+      (helpCommand.command.startsWith(bin) ? '' : `${bin} `) +
+      helpCommand.command +
+      (helpCommand.isRunable ? '' : ' <cmd>'),
+    );
+
     if (helpCommand.description) {
       displayTexts.push('', helpCommand.description);
+    }
+
+    // show examples
+    if (helpCommand.examples?.length) {
+      commandLineUsageList.push({
+        header: 'Examples',
+        content: helpCommand.examples
+          .map(info => (
+            (info.description ? `# ${info.description}\n` : '') +
+            info.command
+          ))
+          .join('\n\n'),
+      });
     }
 
     // available commands, display all subcommands if match the root command
     const availableCommands = (
       helpCommand.isRoot
         ? Array.from(new Set(ctx.commands.values()))
-        : [ helpCommand ].concat(helpCommand.childs || [])
+        : helpCommand.childs || []
     ).filter(c => !c.isRoot && c.isRunable);
 
     if (availableCommands.length) {

--- a/test/fixtures/my-bin/cmd/dev.ts
+++ b/test/fixtures/my-bin/cmd/dev.ts
@@ -3,6 +3,11 @@ import { DefineCommand, Command, Option } from '@artus-cli/artus-cli';
 @DefineCommand({
   command: 'dev [baseDir]',
   description: 'Run the development server',
+  examples: [
+    [ '$0 dev ./', 'Run in base dir' ],
+    [ '$0 dev ./ --port=3000', 'Run with port' ],
+    [ '$0 dev ./ --debug' ],
+  ],
   alias: [ 'd' ],
 })
 export class DevCommand extends Command {

--- a/test/fixtures/no-root-bin/bin/cli.ts
+++ b/test/fixtures/no-root-bin/bin/cli.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+import { start } from '@artus-cli/artus-cli';
+start();

--- a/test/fixtures/no-root-bin/cmd/dev.ts
+++ b/test/fixtures/no-root-bin/cmd/dev.ts
@@ -1,0 +1,10 @@
+import { DefineCommand, Command } from '@artus-cli/artus-cli';
+
+@DefineCommand({
+  command: '$0 dev [baseDir]',
+})
+export class DevCommand extends Command {
+  async run() {
+    console.info('hello');
+  }
+}

--- a/test/fixtures/no-root-bin/cmd/module.ts
+++ b/test/fixtures/no-root-bin/cmd/module.ts
@@ -1,0 +1,19 @@
+import { DefineCommand, Command } from '@artus-cli/artus-cli';
+
+@DefineCommand({
+  command: '$0 module dev [baseDir]',
+})
+export class ModuleDevCommand extends Command {
+  async run() {
+    console.info('hello');
+  }
+}
+
+@DefineCommand({
+  command: '$0 module debug [baseDir]',
+})
+export class ModuleDebugCommand extends Command {
+  async run() {
+    console.info('hello');
+  }
+}

--- a/test/fixtures/no-root-bin/config/plugin.ts
+++ b/test/fixtures/no-root-bin/config/plugin.ts
@@ -1,0 +1,8 @@
+import path from 'node:path';
+
+export default {
+  help: {
+    enable: true,
+    path: path.resolve(__dirname, '../../../../src'),
+  },
+};

--- a/test/fixtures/no-root-bin/package.json
+++ b/test/fixtures/no-root-bin/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "other-bin",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "bin": {
+    "noroot": "./bin/cli.js"
+  }
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -19,7 +19,7 @@ describe('test/index.test.ts', () => {
   it('should subcommand --help', async () => {
     await run('my-bin', 'dev -h')
       .debug()
-      .expect('stdout', /Available Commands/)
+      .notExpect('stdout', /Available Commands/)
       .notExpect('stdout', /help \[command\]\s+show help infomation for command/)
       .notExpect('stdout', /test \<baseDir\> \[file\.\.\.\]\s+Run the unitest/)
       .notExpect('stdout', /cov \<baseDir\> \[file\.\.\.\]\s+Run the coverage/)
@@ -46,7 +46,7 @@ describe('test/index.test.ts', () => {
 
     await run('my-bin', 'help dev')
       // .debug()
-      .expect('stdout', /Available Commands/)
+      .notExpect('stdout', /Available Commands/)
       .notExpect('stdout', /help \[command\]\s+show help infomation for command/)
       .notExpect('stdout', /test \<baseDir\> \[file\.\.\.\]\s+Run the unitest/)
       .notExpect('stdout', /cov \<baseDir\> \[file\.\.\.\]\s+Run the coverage/)
@@ -59,7 +59,7 @@ describe('test/index.test.ts', () => {
   });
 
   it('should show help info when throw built-in error', async () => {
-    await run('my-bin', 'notexistscommand -h')
+    await run('my-bin', 'notexistscommand')
       .debug()
       .expect('stderr', /Command is not found/)
       .expect('stderr', /notexistscommand/)
@@ -101,6 +101,35 @@ describe('test/index.test.ts', () => {
       .expect('stdout', /debug \[baseDir\]\s+Run the development server at debug mode/)
       .expect('stdout', /Options/)
       .expect('stdout', /-h, --help\s+Show Help/)
+      .end();
+  });
+
+  it('should show help with no root bin without error', async () => {
+    await run('no-root-bin', '-h')
+      .debug()
+      .expect('stdout', /Usage: noroot/)
+      .expect('stdout', /Available Commands/)
+      .expect('stdout', /dev \[baseDir\]/)
+      .end();
+
+    await run('no-root-bin', 'dev -h')
+      .debug()
+      .expect('stdout', /Usage: noroot dev \[baseDir\]/)
+      .notExpect('stdout', /Available Commands/)
+      .end();
+
+    await run('no-root-bin', 'module -h')
+      .debug()
+      .expect('stdout', /Usage: noroot module <cmd>/)
+      .expect('stdout', /Available Commands/)
+      .expect('stdout', /module dev \[baseDir\]/)
+      .expect('stdout', /module debug \[baseDir\]/)
+      .end();
+  });
+
+  it('should show examples info', async () => {
+    await run('my-bin', 'dev --help')
+      .debug()
       .end();
   });
 });


### PR DESCRIPTION
支持打印 examples 信息

```
Usage: my-bin dev [baseDir]

Run the development server

Examples

  # Run in base dir                                                             
  my-bin dev ./                                                                 
                                                                                
  # Run with port                                                               
  my-bin dev ./ --port=3000                                                     
                                                                                
  my-bin dev ./ --debug                                                         

Options

  -h, --help            Show Help                 
  -p, --port number     Start A Server            
  --inspect             Debug with node-inspector 
  --throw                                         
  --node-flags string
```